### PR TITLE
Clean up debian repository

### DIFF
--- a/.github/workflows/reprepro-manual.yaml
+++ b/.github/workflows/reprepro-manual.yaml
@@ -21,7 +21,6 @@ jobs:
         env:
             R2_BUCKET: ${{ vars.R2_BUCKET }}
             R2_DB_BUCKET: ${{ vars.R2_DB_BUCKET }}
-            R2_INCOMING_BUCKET: ${{ vars.R2_INCOMING_BUCKET }}
             R2_URL: ${{ vars.CF_R2_S3_API }}
         steps:
             - uses: actions/checkout@v3

--- a/.github/workflows/reprepro-manual.yaml
+++ b/.github/workflows/reprepro-manual.yaml
@@ -1,0 +1,70 @@
+name: Manual Reprepro
+on:
+    workflow_dispatch:
+        inputs:
+            command:
+                description: The command to run, excluding `reprepro -b debian`
+                required: true
+                type: string
+            deploy:
+                description: Whether to deploy changes back
+                required: false
+                type: boolean
+                default: true
+# Protect reprepro database using concurrency
+concurrency: reprepro
+jobs:
+    reprepro:
+        name: Run reprepro
+        environment: packages.element.io
+        runs-on: ubuntu-latest
+        env:
+            R2_BUCKET: ${{ vars.R2_BUCKET }}
+            R2_DB_BUCKET: ${{ vars.R2_DB_BUCKET }}
+            R2_INCOMING_BUCKET: ${{ vars.R2_INCOMING_BUCKET }}
+            R2_URL: ${{ vars.CF_R2_S3_API }}
+        steps:
+            - uses: actions/checkout@v3
+
+            - name: Load GPG key
+              uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549 # v5
+              with:
+                  gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+                  passphrase: ${{ secrets.GPG_PASSPHRASE }}
+                  fingerprint: ${{ vars.GPG_FINGERPRINT }}
+
+            - name: Install reprepro
+              run: sudo apt-get install -y reprepro
+
+            - name: Fetch database
+              run: aws s3 cp --recursive "s3://$R2_DB_BUCKET" debian/db/ --endpoint-url "$R2_URL" --region auto
+              env:
+                  AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_TOKEN }}
+
+            - name: Run reprepro
+              run: |
+                  reprepro -b debian ${{ inputs.command }}
+
+            - name: Deploy debian repo
+              if: inputs.deploy
+              run: |
+                  aws s3 cp --recursive packages.element.io/debian/ "s3://$R2_BUCKET/debian" --endpoint-url "$R2_URL" --region auto
+              env:
+                  AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_TOKEN }}
+
+            - name: Store database
+              if: inputs.deploy
+              run: aws s3 cp --recursive debian/db/ "s3://$R2_DB_BUCKET" --endpoint-url "$R2_URL" --region auto
+              env:
+                  AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_TOKEN }}
+
+            - uses: actions/upload-artifact@v3
+              if: !inputs.deploy
+              with:
+                  name: packages.element.io
+                  path: |
+                      packages.element.io
+                      debian

--- a/debian/conf/distributions
+++ b/debian/conf/distributions
@@ -1,6 +1,6 @@
 Origin: riot.im
 Codename: default
-Architectures: amd64 i386 source
+Architectures: amd64 source
 Components: main
 SignWith: D7B0B66941D01538
 Tracking: minimal
@@ -8,7 +8,7 @@ Tracking: minimal
 Origin: riot.im
 Suite: oldoldstable
 Codename: jessie
-Architectures: amd64 i386 source
+Architectures: amd64 source
 Components: main
 SignWith: D7B0B66941D01538
 Tracking: minimal
@@ -16,7 +16,7 @@ Tracking: minimal
 Origin: riot.im
 Suite: oldstable
 Codename: stretch
-Architectures: amd64 i386 source
+Architectures: amd64 source
 Components: main
 SignWith: D7B0B66941D01538
 Tracking: minimal
@@ -24,7 +24,7 @@ Tracking: minimal
 Origin: riot.im
 Suite: testing
 Codename: bullseye
-Architectures: amd64 i386 source
+Architectures: amd64 source
 Components: main
 SignWith: D7B0B66941D01538
 Tracking: minimal
@@ -32,21 +32,21 @@ Tracking: minimal
 Origin: riot.im
 Suite: unstable
 Codename: sid
-Architectures: amd64 i386 source
+Architectures: amd64 source
 Components: main
 SignWith: D7B0B66941D01538
 Tracking: minimal
 
 Origin: riot.im
 Codename: xenial
-Architectures: amd64 i386 source
+Architectures: amd64 source
 Components: main
 SignWith: D7B0B66941D01538
 Tracking: minimal
 
 Origin: riot.im
 Codename: bionic
-Architectures: amd64 i386 source
+Architectures: amd64 source
 Components: main
 SignWith: D7B0B66941D01538
 Tracking: minimal

--- a/debian/conf/distributions
+++ b/debian/conf/distributions
@@ -1,6 +1,6 @@
 Origin: riot.im
 Codename: default
-Architectures: amd64 source
+Architectures: amd64 arm64 source
 Components: main
 SignWith: D7B0B66941D01538
 Tracking: minimal


### PR DESCRIPTION
We haven't shipped an i386 build since 2020-07-15
We also don't need the transitional riot-* packages anymore, those haven't been needed since 2020
We want to soon start shipping arm64 builds, we only support `default` suite now so we only add it for that suite.

Following this landing, the following reprepro commands need running:

```
reprepro -b debian --delete clearvanished
reprepro -b debian remove default riot-desktop riot-nightly
reprepro -b debian flood default arm64
```

They will be executed one at a time with a dry-run and manual diff to assure nothing goes awry